### PR TITLE
Use group_by_arrival_time; drop alternating framing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,11 +59,8 @@ the oTree documentation) which change the text but not the game rules and
 payoffs. This is controlled with a custom integer session parameter "framing".
 The default configuration offers multiple suggested sessions:
 
-* ``alternative_framing`` using ``framing=0`` (alternates at group level)
-* ``farmer_framing`` using ``framing=1`` (for to all participants)
-* ``community_centre_framing`` using ``framing=2`` (for to all participants)
+* ``farmer_framing`` using ``framing=0`` (for all participants)
+* ``community_centre_framing`` using ``framing=1`` (for all participants)
 
-You suggest one large ``alternative_framing`` session where oTree controls
-which participant gets which framing, or two smaller parallel sessions of
-``farmer_framing`` and ``community_centre_framing`` which lets you control
-which session, and thus which framing, each participant is assigned to.
+We run parallel sessions for each framing, giving control over which session,
+and thus which framing, each participant is assigned to.

--- a/settings.py
+++ b/settings.py
@@ -1,11 +1,11 @@
 from os import environ
 SESSION_CONFIG_DEFAULTS = dict(real_world_currency_per_point=0.05, participation_fee=5)
-SESSION_CONFIGS = [dict(name='alternating_framing', framing=0, num_demo_participants=12, app_sequence=['risk_attitude', 'volunteering', 'questionnaire_and_payment']), dict(name='farmer_framing', framing=1, num_demo_participants=None, app_sequence=['risk_attitude', 'volunteering', 'questionnaire_and_payment']), dict(name='community_centre_framing', framing=2, num_demo_participants=None, app_sequence=['risk_attitude', 'volunteering', 'questionnaire_and_payment'])]
+SESSION_CONFIGS = [dict(name='farmer_framing', framing=0, num_demo_participants=None, app_sequence=['risk_attitude', 'volunteering', 'questionnaire_and_payment']), dict(name='community_centre_framing', framing=1, num_demo_participants=None, app_sequence=['risk_attitude', 'volunteering', 'questionnaire_and_payment'])]
 LANGUAGE_CODE = 'en'
 REAL_WORLD_CURRENCY_CODE = 'GBP'
 USE_POINTS = True
 DEMO_PAGE_INTRO_HTML = ''
-PARTICIPANT_FIELDS = ['risk_attitude_msg', 'volunteering_msg', 'volunteering_framing']
+PARTICIPANT_FIELDS = ['risk_attitude_msg', 'volunteering_msg']
 SESSION_FIELDS = []
 ROOMS = []
 

--- a/unpack_otreezip
+++ b/unpack_otreezip
@@ -57,9 +57,8 @@ def main():
     # Cannot set DEMO_PAGE_INTRO_HTML in oTree Studio:
     run("""echo "DEMO_PAGE_INTRO_HTML = 'Risk attitude lottery game based on Holt and Laury (2002), followed by an interactive multi-player game about volunteering. <a href=\\\"https://github.com/peterjc/MDT-INTR-EXP-MET\\\">Source code on GitHub</a>.'" >> settings.py""")
     # Cannot set custom session parameters in free oTree Studio:
-    run("""sed -i.bak "s#name='alternating_framing', num_demo_participants=#name='alternating_framing', framing=0, num_demo_participants=#g" settings.py""")
-    run("""sed -i.bak "s#name='farmer_framing', num_demo_participants=#name='farmer_framing', framing=1, num_demo_participants=#g" settings.py""")
-    run("""sed -i.bak "s#name='community_centre_framing', num_demo_participants=#name='community_centre_framing', framing=2, num_demo_participants=#g" settings.py""")
+    run("""sed -i.bak "s#name='farmer_framing', num_demo_participants=#name='farmer_framing', framing=0, num_demo_participants=#g" settings.py""")
+    run("""sed -i.bak "s#name='community_centre_framing', num_demo_participants=#name='community_centre_framing', framing=1, num_demo_participants=#g" settings.py""")
     # run("""echo "POINTS_CUSTOM_NAME = 'tokens'" >> settings.py""")
     # run("black")
 

--- a/volunteering/tests.py
+++ b/volunteering/tests.py
@@ -9,7 +9,14 @@ class PlayerBot(Bot):
     pre_game_payoff = {}
 
     def play_round(self):
-        if self.participant.volunteering_framing:
+        if self.session.config["name"] == "farmer_framing":
+            # framing=0 gives False, farmers
+            expect(self.session.config.get('framing', None), 0)
+        elif self.session.config["name"] == "community_centre_framing":
+            # framing=1 gives True, Community Centre
+            expect(self.session.config.get('framing', None), 1)
+        volunteering_framing = bool(self.session.config.get('framing', 0))
+        if volunteering_framing:
             right_framing = "community centre"
             wrong_framing = "farmer"
         else:


### PR DESCRIPTION
We expect to run this experiment with a large number of participants, so potentially many groups might be stalled waiting for their slowest player to reach the volunteering dilemma. It is therefore helpful to use oTree's ``group_by_arrival_time`` functionality for that game.

i.e. The first 6 players to reach the volunteering game play together as a group, then the next 6 etc. If there are any spare players they will wait forever (unless we add a new player, or force-advance the absentees), but that leaves only one group potentially stalled which is a big improvement.

https://otree.readthedocs.io/en/latest/multiplayer/waitpages.html#group-by-arrival-time

However, using ``group_by_arrival_time``  alters how and when the groups are allocated, and I was unable to get the allocation of alternating framing to still work. i.e. First 6 to start the volunteering game are farmers, next 6 are community centre users, etc:

https://groups.google.com/g/otree/c/2M15wahC7a8

We are now planning to use two parallel sessions for the two framings anyway:

https://groups.google.com/g/otree/c/R_2oh2UbcHc

So easiest to drop the code to alternate the groups' framing, and can now just use the session configuration directly & drop the extra participant field. i.e. This makes the code simpler :)